### PR TITLE
Drop stabilized and removed feature gates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,6 @@
 //!     "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"
 //! );
 //! ```
-#![feature(const_fn)]
-#![feature(const_if_match)]
-#![feature(const_loop)]
 #![feature(const_mut_refs)]
 #![no_std]
 


### PR DESCRIPTION
`const_if_match` and `const_loop` are stable since 1.46, `const_fn` has been removed in favor of more fine-grained feature gates.

Please cut a release if you merge this.