### PR TITLE
make it work on stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //!     "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"
 //! );
 //! ```
-#![feature(const_mut_refs)]
 #![no_std]
 
 mod constants;
@@ -80,7 +79,7 @@ macro_rules! sha {
             /// Add input data to the hash context.
             #[must_use]
             pub const fn update(mut self, input: &[u8]) -> Self {
-                self.inner.update(&input);
+                self.inner = self.inner.update(&input);
                 self
             }
 
@@ -89,7 +88,7 @@ macro_rules! sha {
             pub const fn finalize(self) -> [u8; Self::DIGEST_SIZE] {
                 let digest = self.inner.finalize();
                 let mut truncated = [0; Self::DIGEST_SIZE];
-                memcpy(&mut truncated, 0, &digest, 0, Self::DIGEST_SIZE);
+                truncated = memcpy(truncated, 0, &digest, 0, Self::DIGEST_SIZE);
                 truncated
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,30 +4,37 @@
 /// The source and destination must _not_ overlap. This function exists because
 /// subslices are not supported in `const fn`.
 #[inline(always)]
-pub(crate) const fn memcpy(
-    dest: &mut [u8],
+pub(crate) const fn memcpy<const N: usize>(
+    mut dest: [u8; N],
     dest_offset: usize,
     src: &[u8],
     src_offset: usize,
     n: usize,
-) {
+) -> [u8; N] {
     let mut i = 0;
     while i < n {
         dest[dest_offset + i] = src[src_offset + i];
         i += 1;
     }
+    dest
 }
 
 /// Sets `n` bytes in `dest` (starting at `dest_offset`) to `val`.
 ///
 /// This function exists because subslices are not supported in `const fn`.
 #[inline(always)]
-pub(crate) const fn memset(dest: &mut [u8], offset: usize, val: u8, n: usize) {
+pub(crate) const fn memset<const N: usize>(
+    mut dest: [u8; N],
+    offset: usize,
+    val: u8,
+    n: usize,
+) -> [u8; N] {
     let mut i = 0;
     while i < n {
         dest[offset + i] = val;
         i += 1;
     }
+    dest
 }
 
 /// Loads an unsigned 32-bit big endian integer from `src` (starting at
@@ -67,9 +74,9 @@ pub(crate) const fn load_u64_be(src: &[u8], offset: usize) -> u64 {
 ///
 /// This function exists because subslices are not supported in `const fn`.
 #[inline(always)]
-pub(crate) const fn store_u32_be(dest: &mut [u8], offset: usize, n: u32) {
+pub(crate) const fn store_u32_be<const N: usize>(dest: [u8; N], offset: usize, n: u32) -> [u8; N] {
     let bytes = u32::to_be_bytes(n);
-    memcpy(dest, offset, &bytes, 0, bytes.len());
+    memcpy(dest, offset, &bytes, 0, bytes.len())
 }
 
 /// Stores an unsigned 64-bit big endian integer into `dest` (starting at
@@ -77,9 +84,9 @@ pub(crate) const fn store_u32_be(dest: &mut [u8], offset: usize, n: u32) {
 ///
 /// This function exists because subslices are not supported in `const fn`.
 #[inline(always)]
-pub(crate) const fn store_u64_be(dest: &mut [u8], offset: usize, n: u64) {
+pub(crate) const fn store_u64_be<const N: usize>(dest: [u8; N], offset: usize, n: u64) -> [u8; N] {
     let bytes = u64::to_be_bytes(n);
-    memcpy(dest, offset, &bytes, 0, bytes.len());
+    memcpy(dest, offset, &bytes, 0, bytes.len())
 }
 
 /// Stores an unsigned 128-bit big endian integer into `dest` (starting at
@@ -87,7 +94,11 @@ pub(crate) const fn store_u64_be(dest: &mut [u8], offset: usize, n: u64) {
 ///
 /// This function exists because subslices are not supported in `const fn`.
 #[inline(always)]
-pub(crate) const fn store_u128_be(dest: &mut [u8], offset: usize, n: u128) {
+pub(crate) const fn store_u128_be<const N: usize>(
+    dest: [u8; N],
+    offset: usize,
+    n: u128,
+) -> [u8; N] {
     let bytes = u128::to_be_bytes(n);
-    memcpy(dest, offset, &bytes, 0, bytes.len());
+    memcpy(dest, offset, &bytes, 0, bytes.len())
 }


### PR DESCRIPTION
I wanted to use sha2 in const context on stable rust.

This commit allows using the sha2 routines without nightly rust. This is done by manipulating (and returning) owned arrays rather than passing mutable slices.