### PR TITLE
fix compiler error from stabilized feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //!     "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"
 //! );
 //! ```
-#![feature(const_mut_refs)]
 #![no_std]
 
 mod constants;


### PR DESCRIPTION
thanks for making this crate. i noticed the macro `const_mut_refs` was stabilized into Rust, and compilation now fails unless this flag is removed.